### PR TITLE
Fix issue with not restarting after disconnects

### DIFF
--- a/Dockerfile-discord-shard
+++ b/Dockerfile-discord-shard
@@ -3,9 +3,9 @@ ARG package=release
 
 #ADD "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.0l-1~deb9u6_amd64.deb" .
 #RUN dpkg -i libssl1.1*deb
-ADD "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb" .
+ADD "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.21_amd64.deb" .
 RUN dpkg -i libssl*deb
-ADD "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.16_amd64.deb" .
+ADD "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1-1ubuntu2.1~18.04.21_amd64.deb" .
 RUN dpkg -i openssl*deb
 ADD "http://security.ubuntu.com/ubuntu/pool/main/c/ca-certificates/ca-certificates-udeb_20211016ubuntu0.18.04.1_all.udeb" .
 RUN dpkg -i ca-certificates*deb

--- a/src/shard/main.rs
+++ b/src/shard/main.rs
@@ -1120,6 +1120,11 @@ async fn monitor_total_shards(shard_manager: Arc<Mutex<serenity::client::bridge:
         let db_total_shards: u64 = db_total_shards.expect("Failed to get or convert total_shards from Redis");
 
         let mut shard_manager = shard_manager.lock().await;
+        if !shard_manager.has(serenity::client::bridge::gateway::ShardId(shard_id)).await {
+            debug!("Shard {} not found, marking self for termination.", shard_id);
+            fs::remove_file("/etc/probes/live").expect("Unable to remove /etc/probes/live");
+        }
+
         if db_total_shards != total_shards {
             debug!("Total shards changed from {} to {}, restarting.", total_shards, db_total_shards);
             shard_manager.set_shards(shard_id, 1, db_total_shards).await;


### PR DESCRIPTION
If a shard disconnects and gets stuck starting, the health check will report as healthy, even though it's stuck starting. Added a check every 60 seconds to make sure shard is connected.