### PR TITLE
Add Resource Manager for connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,13 +28,10 @@ discord-roles/target/
 shard/target/
 
 Kubernetes/
-<<<<<<< Updated upstream
-=======
 
 reddit-downloader/src/downloaders/secrets.txt
 reddit-downloader/test-data
 
 .vscode/
->>>>>>> Stashed changes
 
 badge-server/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ reddit-downloader/test-data
 
 .vscode/
 >>>>>>> Stashed changes
+
+badge-server/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "connection-pooler"
+version = "0.1.0"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,8 +330,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "connection-pooler"
+name = "connection_pooler"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serenity 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+]
 
 [[package]]
 name = "convert_case"
@@ -658,6 +663,7 @@ name = "discord-shard"
 version = "1.0.3"
 dependencies = [
  "anyhow",
+ "connection_pooler",
  "env_logger",
  "futures",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "serenity 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ members = [
     "k8s-interface",
     "posthog",
     "rslash_types",
-    "badge-server"
+    "badge-server",
+    "connection-pooler",
 ]
 
 [profile.release]

--- a/connection-pooler/Cargo.toml
+++ b/connection-pooler/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 tracing = "*"
 anyhow = "*"
 serenity = {version = "*", features = ["client"]}
+tokio = {version = "*", features = ["sync"]}

--- a/connection-pooler/Cargo.toml
+++ b/connection-pooler/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "connection-pooler"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/connection-pooler/Cargo.toml
+++ b/connection-pooler/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
-name = "connection-pooler"
+name = "connection_pooler"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tracing = "*"
+anyhow = "*"
+serenity = {version = "*", features = ["client"]}

--- a/connection-pooler/src/lib.rs
+++ b/connection-pooler/src/lib.rs
@@ -1,6 +1,8 @@
-use tracing::warn;
+use serenity::futures::{stream, StreamExt};
+use tracing::{warn, info};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -20,7 +22,7 @@ impl <T> LockedResource<T> {
 }
 
 #[derive(Clone)]
-pub struct ResourceManager<T> {
+pub struct ResourceManager<T: Send + Sync> {
     resources: Arc<Mutex<Vec<Arc<LockedResource<T>>>>>,
     maker: Arc<Box<dyn Fn() -> T + Send + Sync>>,
 }
@@ -42,22 +44,22 @@ impl <T> ResourceManager<T> where T: Send + Sync + 'static {
 
         // Spawn a background thread for cleanup
         let resource_manager = new.clone();
-        thread::spawn(move || {
+        thread::spawn(move || async move {
             loop {
                 thread::sleep(Duration::from_secs(60)); // Adjust the interval as needed
 
                 // Remove locks that have been held for too long
-                resource_manager.remove_unavailable();
+                resource_manager.remove_unavailable().await;
             }
         });
 
         new
     }
 
-    pub fn get_available_resource(&self) -> Arc<Mutex<T>> {
-        self.remove_unavailable();
+    pub async fn get_available_resource(&self) -> Arc<Mutex<T>> {
+        self.remove_unavailable().await;
 
-        let resources = self.resources.lock().expect("Failed to lock resources");
+        let resources = self.resources.lock().await;
         let mut available = Option::None;
         for resource in &*resources {
             match resource.data.try_lock() {
@@ -74,33 +76,40 @@ impl <T> ResourceManager<T> where T: Send + Sync + 'static {
         let available = match available {
             Some(resource) => resource,
             None => {
+                info!("Creating new resource");
                 let resource = Arc::new(LockedResource::new(self.maker.clone()));
-                self.add(resource.clone());
+                self.add(resource.clone()).await;
                 resource
             }
         };
 
-        *available.last_accessed.lock().unwrap() = Instant::now();
+        *available.last_accessed.lock().await = Instant::now();
 
         available.data.clone()
 
     }
 
-    fn remove_unavailable(&self) {
-        let mut resources = self.resources.lock().unwrap();
-        resources.retain(|resource| {
+    // Remove one unavailable resource if it has been unavailable for more than 2 minutes
+    async fn remove_unavailable(&self) {
+        let mut resources_lock: tokio::sync::MutexGuard<'_, Vec<Arc<LockedResource<T>>>> = self.resources.lock().await;
+
+        let mut to_remove = 0;
+        for (i, resource) in resources_lock.iter().enumerate() {
+            let _ = resource.data.try_lock();
             let locked = resource.data.try_lock().is_err();
-            if resource.last_accessed.lock().unwrap().elapsed() > Duration::from_secs(120)  && locked{
+            if resource.last_accessed.lock().await.elapsed() > Duration::from_secs(120)  && locked{
                 warn!("Removing unavailable resource");
-                false // Don't retain the lock
-            } else {
-                true // Retain the lock
+                to_remove = i;
+                break
             }
-        });
+        }
+        let resources = &mut *resources_lock;
+        resources.swap_remove(to_remove);
+
     }
 
-    fn add(&self, resource: Arc<LockedResource<T>>) {
-        let mut resources = self.resources.lock().unwrap();
+    async fn add(&self, resource: Arc<LockedResource<T>>) {
+        let mut resources = self.resources.lock().await;
         resources.push(resource);
     }
 

--- a/connection-pooler/src/lib.rs
+++ b/connection-pooler/src/lib.rs
@@ -1,0 +1,99 @@
+use std::sync::{Arc, Mutex};
+use std::cell::RefCell;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+struct LockedResource<T> {
+    lock: Arc<Mutex<()>>,
+    last_accessed: Arc<Mutex<Instant>>,
+    data: Arc<Mutex<T>>,
+}
+
+impl <T> LockedResource<T> {
+    fn new<M: Fn() -> T + ?Sized>(maker: Arc<Box<M>>) -> Self {
+        Self {
+            lock: Arc::new(Mutex::new(())),
+            last_accessed: Arc::new(Mutex::new(Instant::now())),
+            data: Arc::new(Mutex::new(maker())),
+        }
+    }
+}
+
+struct ResourceManager<T> {
+    resources: Arc<Mutex<Vec<Arc<LockedResource<T>>>>>,
+    maker: Arc<Box<dyn Fn() -> T + Send + Sync>>,
+}
+
+impl <T> ResourceManager<T> where T: Send + Sync + 'static {
+    fn new<M : Fn() -> T + Send + Sync + 'static>(maker: M) -> Arc<Self> {
+        let new = Self {
+            resources: Arc::new(Mutex::new(Vec::new())),
+            maker: Arc::new(Box::new(maker)),
+        };
+
+        // Spawn a background thread for cleanup
+        let resource_manager = Arc::new(new);
+        let to_return = resource_manager.clone();
+        thread::spawn(move || {
+            loop {
+                thread::sleep(Duration::from_secs(5)); // Adjust the interval as needed
+
+                // Remove locks that have been held for too long
+                resource_manager.remove_unavailable();
+                let lock = resource_manager.resources.lock().expect("Failed to lock");
+                println!("Removed deadlocks, new resources length: {}", lock.len());
+            }
+        });
+
+        to_return
+    }
+
+    fn get_available_resource(&self) -> Arc<LockedResource<T>> {
+        self.remove_unavailable();
+
+        let resources = self.resources.lock().expect("Failed to lock resources");
+        let mut available = Option::None;
+        for resource in &*resources {
+            match resource.data.try_lock() {
+                Ok(_) => {
+                    available = Some(Arc::clone(resource));
+                    break;
+                },
+                Err(_) => {
+
+                }
+            }
+        }
+
+        let available = match available {
+            Some(resource) => resource,
+            None => {
+                let resource = Arc::new(LockedResource::new(self.maker.clone()));
+                self.add(resource.clone());
+                resource
+            }
+        };
+
+        available
+
+    }
+
+    fn remove_unavailable(&self) {
+        let mut resources = self.resources.lock().unwrap();
+        resources.retain(|resource| {
+            if resource.last_accessed.lock().unwrap().elapsed() > Duration::from_secs(10) {
+                println!("Removing lock");
+                false // Don't retain the lock
+            } else {
+                true // Retain the lock
+            }
+        });
+    }
+
+    fn add(&self, resource: Arc<LockedResource<T>>) {
+        let mut resources = self.resources.lock().unwrap();
+        resources.push(resource);
+    }
+
+}

--- a/connection-pooler/src/lib.rs
+++ b/connection-pooler/src/lib.rs
@@ -1,5 +1,6 @@
 use tracing::warn;
-use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 

--- a/memberships/src/lib.rs
+++ b/memberships/src/lib.rs
@@ -23,17 +23,6 @@ pub struct Client<'a> {
     client: &'a mut mongodb::Client,
 }
 
-impl <'a> From<&'a mut tokio::sync::RwLockWriteGuard<'_, serenity::prelude::TypeMap>> for Client<'a> {
-    fn from(data: &'a mut tokio::sync::RwLockWriteGuard<'_, serenity::prelude::TypeMap>) -> Client<'a> {
-        let mongodb_client: &mut mongodb::Client = match data.get_mut::<ConfigStruct>().unwrap().get_mut("mongodb_connection").unwrap() {
-            ConfigValue::MONGODB(db) => Ok(db),
-            _ => Err(0),
-        }.unwrap();
-        Client {
-            client: mongodb_client,
-        }
-    }
-}
 
 impl <'a> From<&'a mut mongodb::Client> for Client<'a> {
     fn from(client: &'a mut mongodb::Client) -> Client<'a> {

--- a/memberships/src/lib.rs
+++ b/memberships/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use rslash_types::*;
 use mongodb::bson::{doc, Document};
@@ -8,6 +9,8 @@ use log::*;
 use serenity::futures::TryStreamExt;
 
 use serde_derive::{Deserialize, Serialize};
+use serenity::prelude::TypeMap;
+use tokio::sync::RwLock;
 
 #[cfg(test)]
 mod tests {
@@ -31,6 +34,7 @@ impl <'a> From<&'a mut mongodb::Client> for Client<'a> {
         }
     }
 }
+
 
 #[derive(Debug)]
 pub struct MembershipTier {

--- a/rslash_types/src/lib.rs
+++ b/rslash_types/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::RwLock};
 
 #[cfg(test)]
 mod tests {
@@ -20,11 +20,12 @@ pub enum ConfigValue {
     PosthogClient(posthog::Client),
 }
 
-/// Stores config values required for operation of the downloader
+/// Stores config values required for operation of the shard
 pub struct ConfigStruct {
-    _value: HashMap<String, ConfigValue>
+    pub shard_id: u64,
+    pub nsfw_subreddits: Vec<String>,
 }
 
 impl serenity::prelude::TypeMapKey for ConfigStruct {
-    type Value = HashMap<String, ConfigValue>;
+    type Value = ConfigStruct;
 }

--- a/shard/Cargo.toml
+++ b/shard/Cargo.toml
@@ -28,6 +28,7 @@ tracing-subscriber = { version = "*"}
 posthog = {path = "../posthog"}
 memberships = {path = "../memberships"}
 rslash_types = {path = "../rslash_types"}
+connection_pooler = {path = "../connection-pooler"}
 
 [[bin]]
 name = "discord-shard"


### PR DESCRIPTION
Serenity provides a `RwLock`ed `TypeMap` for sharing global state between interactions (e.g. for connections). The issue with this is that connections have to be accessed mutably, meaning each interaction has to acquire an exclusive lock on the map. This could potentially cause interactions to have to wait for other commands to finish, which isn't much of an issue since per-shard load isn't very high. However, in edge cases interactions can take a long time to complete, or sometimes not complete at all. This would deadlock the entire shard, meaning no other commands could run.

As a solution I wrote a type `ResourceManager` which holds a collection of user specified type. Each resource in the collection is protected by its own lock, with a timestamp of when it was last locked. The user provides an asynchronous closure when instantiating the `ResourceManager` which can be used to instantiate a new resource. When the user needs to access a resource (e.g. a connection), it simply calls a method on `ResourceManager` to get an available one. If all the resources in the collection are locked, it will instantiate a new one from the closure. The `ResourceManager` periodically polls the contained resource locks, purging resources that have been locked for too long.