### PR TITLE
v1.1.15 - Fix race condition & incorrect minimum-finding logic

### DIFF
--- a/reddit-downloader/src/main.rs
+++ b/reddit-downloader/src/main.rs
@@ -502,10 +502,12 @@ async fn get_subreddit(subreddit: String, con: &mut redis::aio::MultiplexedConne
             }
         }
 
-        if (keys.len() != 0) {
+        if keys.len() != 0 {
+            redis::cmd("MULTI").query_async(con).await?;
             con.del(format!("subreddit:{}:posts", subreddit)).await?;
             con.rpush(format!("subreddit:{}:posts", subreddit), keys.clone()).await?;
-        }
+            redis::cmd("EXEC").query_async(con).await?;
+        };
 
 
         let time_since_request = get_epoch_ms()? - last_requested;

--- a/shard/Cargo.lock
+++ b/shard/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "discord-shard"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/shard/Cargo.toml
+++ b/shard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discord-shard"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/shard/src/reddit.rs
+++ b/shard/src/reddit.rs
@@ -198,10 +198,12 @@ pub async fn get_subreddit<'a>(subreddit: String, con: &mut redis::aio::Multiple
     let mut post_id: Result<String, Error> = Err(anyhow!("No posts found for subreddit: {}", subreddit));
 
     // Find the first post that the channel has not seen before
-    let mut minimum_post = None;
+    let mut minimum_post: Option<(String, u64)> = None;
     for post in posts {
         if fetched_posts.contains_key(&post) {
-            minimum_post = Some((post, get_epoch_ms()));
+            if minimum_post.is_none() || fetched_posts.get(&post).unwrap() < &minimum_post.clone().unwrap().1 {
+                minimum_post = Some((post.clone(), fetched_posts.get(&post).unwrap().to_owned()));
+            }
         } else {
             post_id = Ok(post);
             break;


### PR DESCRIPTION
- When downloader updated a subreddit list a shard could get the list after it had been deleted but before it had been re-created. Now it is done as one transaction.

- When finding the post seen longest ago it was accidentally just finding the lowest priority post.